### PR TITLE
Add CLI runner and clean Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ FFMPEG_BIN=ffmpeg
 ```
 Never commit real keys.
 
+### 4) Command Line (optional)
+```
+python run_story.py "A letter found at golden hour"
+```
+Outputs `final.mp4` under `./output` by default.
+
 ## With Docker
 ```
 docker compose up --build

--- a/run_story.py
+++ b/run_story.py
@@ -1,0 +1,26 @@
+import argparse
+from pathlib import Path
+import sys
+
+# allow importing from apps/api
+sys.path.append(str(Path(__file__).parent / 'apps' / 'api'))
+
+from pipeline import run_pipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a narrated story video from a prompt")
+    parser.add_argument('prompt', help='Story idea to expand into scenes')
+    parser.add_argument('--voice-id', default=None, help='ElevenLabs voice id')
+    parser.add_argument('--style', default='cinematic soft light', help='Image style prompt suffix')
+    parser.add_argument('--out', default='output', help='Directory to store generated files')
+    args = parser.parse_args()
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run_pipeline(args.prompt, args.voice_id, args.style, out_dir)
+    print(f"Video written to {out_dir / 'final.mp4'}")
+
+
+if __name__ == '__main__':
+    main()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,8 +6,6 @@ import requests
 from PIL import Image, ImageDraw
 from moviepy.editor import ImageClip, AudioFileClip, concatenate_videoclips
 
-ELEVENLABS_API_KEY = 'sk_2704fddcd07b1fd477a349972b28ad8b7984ebc60a18597d'
-
 
 # ---- Streamlit must be configured first ----
 st.set_page_config(page_title="One-Click Story Studio", page_icon="🎬", layout="centered")
@@ -43,19 +41,6 @@ def build_scene_plan(user_prompt: str):
 
 def generate_image_bytes(prompt: str) -> bytes:
     if STABILITY_KEY:
-        url = f"https://api.stability.ai/v1/generation/{STABILITY_ENGINE}/text-to-image"
-        headers = {"Authorization": f"Bearer {STABILITY_KEY}", "Content-Type": "application/json"}
-        payload = {"text_prompts": [{"text": prompt}], "width": 1024, "height": 576, "cfg_scale": 7, "samples": 1, "steps": 30}
-        r = requests.post(url, headers=headers, json=payload, timeout=60); r.raise_for_status()
-        return base64.b64decode(r.json()["artifacts"][0]["base64"])
-    # Placeholder if no Stability key
-    from PIL import Image
-    img = Image.new("RGB", (1024, 576), (180, 180, 180))
-    d = ImageDraw.Draw(img); d.text((20,20), "Image Placeholder", fill=(30,30,30))
-    bio = io.BytesIO(); img.save(bio, format="PNG"); return bio.getvalue()
-
-def generate_image_bytes(prompt: str) -> bytes:
-    if STABILITY_KEY:
         try:
             url = f"https://api.stability.ai/v1/generation/{STABILITY_ENGINE}/text-to-image"
             headers = {"Authorization": f"Bearer {STABILITY_KEY}", "Content-Type": "application/json"}
@@ -71,14 +56,6 @@ def generate_image_bytes(prompt: str) -> bytes:
     img = Image.new("RGB", (1024, 576), (180, 180, 180))
     d = ImageDraw.Draw(img); d.text((20,20), "Image Placeholder", fill=(30,30,30))
     bio = io.BytesIO(); img.save(bio, format="PNG"); return bio.getvalue()
-
-def tts_bytes(text: str, voice_id: str = "21m00Tcm4TlvDq8ikWAM") -> bytes:
-    if not ELEVEN: 
-        return b""
-    headers = {"xi-api-key": ELEVEN, "Accept": "audio/mpeg", "Content-Type": "application/json"}
-    payload = {"text": text, "voice_settings": {"stability": 0.6, "similarity_boost": 0.8}}
-    r = requests.post(f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}", headers=headers, json=payload, timeout=60)
-    r.raise_for_status(); return r.content
 
 def tts_bytes(text: str, voice_id: str = "21m00Tcm4TlvDq8ikWAM") -> bytes:
     if not ELEVEN:


### PR DESCRIPTION
## Summary
- remove hardcoded secret and duplicate functions in `streamlit_app.py`
- add `run_story.py` CLI to execute the full pipeline
- document the command-line option in the README

## Testing
- `python -m py_compile streamlit_app.py run_story.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab38dfce2c832abe85553829fc1ea9